### PR TITLE
I2C Slowdown Fix

### DIFF
--- a/custom_targets.json
+++ b/custom_targets.json
@@ -10,7 +10,7 @@
 	"inherits": ["HU_FAMILY_AIRBORNE", "NRF52_DK"],
 	"features": ["ALS", "BATTERY_FUEL_GAUGE", "STC3115", "TLC59711", "FLASH_AT25SF321", "BLE","COMPARATOR"],
 	"macros_remove": ["BOARD_PCA10040"],
-	"macros_add": ["ENABLE_SWO"],
+	"macros_add": ["ENABLE_SWO", "I2C_TIMEOUT_VALUE_US=1000"],
 	"MERGE_SOFT_DEVICE": false,
 	"bootloader_supported": true,
 	"overrides": {


### PR DESCRIPTION
Added I2C_TIMEOUT macro to HU_FLYER in custom_targets.json to minimize impact of I2C timeouts on application. Patched i2c_api.c to reset the peripheral driver after an error (so errors don't keep propagating).

Fixes HeadsUpDisplayInc/hud-airborne#14

Temporary patch until official Nordic SDK14.2 update hits the mbed master release.

See https://github.com/ARMmbed/mbed-os/tree/feature-nrf528xx